### PR TITLE
handle uncaught runtime errors in 'observe/resolve' as errors

### DIFF
--- a/src/server/query-executor.js
+++ b/src/server/query-executor.js
@@ -8,6 +8,9 @@ var StaticObservable = require('static-observable')
 var graphqlObserve = require('./graphql-observe.js')
 
 var checkForPayloadErrors = function (data) {
+  if (data.data instanceof Error) {
+    throw data.data
+  }
   if (data.errors) {
     if (data.errors.length === 1) {
       throw data.errors[0]

--- a/test/fixtures/graphql-schema.js
+++ b/test/fixtures/graphql-schema.js
@@ -99,6 +99,23 @@ var InvalidSubscription = {
   }
 }
 
+var ObserveThrows = relaySubscription({
+  name: 'ObserveThrows',
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString)
+    }
+  },
+  outputFields: {
+    user: {
+      type: UserType
+    }
+  },
+  observe: () => {
+    throw new Error('observe error')
+  }
+})
+
 var UserChanges = relaySubscription({
   name: 'UserChanges',
   inputFields: {
@@ -215,7 +232,8 @@ var Subscription = new GraphQLObjectType({
   fields: {
     userChanges: UserChanges,
     userChangesPromise: UserChangesPromise,
-    invalidSubscription: InvalidSubscription
+    invalidSubscription: InvalidSubscription,
+    observeThrows: ObserveThrows
   }
 })
 


### PR DESCRIPTION
uncaught errors in query/mutation "resolve" or subscription "observe" are handled as data instead of errors (outside of promises or try/catch)